### PR TITLE
fix: 🐛 sessionStatusの分岐を修正

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,8 +23,8 @@ const Home: NextPageWithLayout = () => {
           <p className="text-center text-liver-400">{topInfo.paragraph}</p>
 
           <div className="h-12">
-            {sessionStatus !== "loading" &&
-            sessionStatus === "unauthenticated" ? (
+            {sessionStatus === "loading" ? null : sessionStatus ===
+              "unauthenticated" ? (
               <LoginButton size="md" />
             ) : (
               <Link


### PR DESCRIPTION
loading中に認証後のコンポーネントを表示させてしまっていたため、分岐を修正した

✅ Closes: #140
